### PR TITLE
[V1][TPU] TPU-optimized top-k implementation (2nd try)

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -138,25 +138,35 @@ def apply_top_k_top_p_tpu(
     This algorithm avoids using torch.scatter which is extremely slow on TPU.
     This is achieved by finding a "cut-off" element in the original logit, and
     after thresholding the logit using this cut-off, the remaining elements
-    shall constitute the top-p set.
+    shall constitute the top-k/p set.
 
     Note: in the case of tie (i.e. multipple cut-off elements present in the
-    logit), all tie elements are included in the top-p set. In other words,
+    logit), all tie elements are included in the top-k/p set. In other words,
     this function does not break ties. Instead, these tie tokens have equal
     chance of being chosen during final sampling, so we can consider the tie
     being broken then.
     """
+    probs = logits.softmax(dim=-1)
+    probs_sort, _ = probs.sort(dim=-1, descending=False)
+
     if k is not None:
-        logits = apply_top_k_only(logits, k)
+        top_k_count = probs_sort.size(1) - k.to(torch.long)  # shape: (batch, )
+        top_k_count = top_k_count.unsqueeze(dim=1)
+        top_k_cutoff = probs_sort.gather(-1, top_k_count)
+
+        # Make sure the no top-k rows are no-op.
+        no_top_k_mask = (k == logits.shape[1]).unsqueeze(dim=1)
+        top_k_cutoff.masked_fill_(no_top_k_mask, -float("inf"))
+
+        elements_to_discard = probs < top_k_cutoff
+        logits.masked_fill_(elements_to_discard, -float("inf"))
 
     if p is not None:
-        probs = logits.softmax(dim=-1)
-        probs_sort, _ = probs.sort(dim=-1, descending=False)
         cumprob = torch.cumsum(probs_sort, dim=-1)
         top_p_mask = cumprob <= 1 - p.unsqueeze(dim=1)
         top_p_mask[:, -1] = False  # at least one
 
-        top_p_count = top_p_mask.sum(dim=-1).unsqueeze(1)
+        top_p_count = top_p_mask.sum(dim=-1).unsqueeze(dim=1)
         top_p_cutoff = probs_sort.gather(-1, top_p_count)
         elements_to_discard = probs < top_p_cutoff
         logits.masked_fill_(elements_to_discard, -float("inf"))


### PR DESCRIPTION
Previously we found that using torch.topk resulted in significant speed up for TPU. Turns out that's not a viable solution because the return shape of torch.topk depends on k, which means an XLA recompilation is triggered everytime k changes.

Additionally, we realized that torch.scatter was the main bottleneck for the original top-k impl on TPU. This PR circumvents both problems by using a threshold-based approach to find the top-k set. The algorithm is nearly identical to that of top-p; see #15736 for more details.

### Benchmark

Sampling microbenchmark result on v6e-1: "Running 32 elapsed time" averages to 3.6 ms (down from 500 ms with scatter-based impl in forward_native).

<details>
<summary>Benchmark log</summary>
```
$ python sampler_microbenchmark.py 
INFO 03-31 21:56:00 [__init__.py:239] Automatically detected platform tpu.
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
INFO 03-31 21:56:06 [topk_topp_sampler.py:82] Using approximate top-p optimized for TPU. Result may in theory differ from the exact algorithm if there are tokens with near-identical probabilities (< 1e-9 diff).
Compiling/Warmup 1 elapsed time: 9.194662809371948
Compiling/Warmup 4 elapsed time: 9.116543054580688
Compiling/Warmup 16 elapsed time: 8.807528018951416
Compiling/Warmup 32 elapsed time: 8.897732019424438
Running 1 elapsed time: 0.002966165542602539
Running 1 elapsed time: 0.002337217330932617
Running 1 elapsed time: 0.002252817153930664
Running 1 elapsed time: 0.002237081527709961
Average time:  0.0024483203887939453
Running 4 elapsed time: 0.0026471614837646484
Running 4 elapsed time: 0.002381563186645508
Running 4 elapsed time: 0.002348661422729492
Running 4 elapsed time: 0.002398967742919922
Average time:  0.0024440884590148926
Running 16 elapsed time: 0.00299835205078125
Running 16 elapsed time: 0.0027778148651123047
Running 16 elapsed time: 0.0027704238891601562
Running 16 elapsed time: 0.0027475357055664062
Average time:  0.0028235316276550293
Running 32 elapsed time: 0.0037496089935302734
Running 32 elapsed time: 0.0035295486450195312
Running 32 elapsed time: 0.0034787654876708984
Running 32 elapsed time: 0.0035245418548583984
Average time:  0.0035706162452697754
```
</details>